### PR TITLE
feat: Add support for multiple AI models in unit test generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # AI Unit Test Generator
 
-A modern web application that uses AI to generate unit tests for your code. Built with Next.js, TypeScript, and OpenAI's GPT-4.
+A modern web application that uses AI to generate unit tests for your code. Built with Next.js, TypeScript, and multiple AI models (OpenAI's GPT-4 and Anthropic's Claude 3 Sonnet).
 
 ## Features
 
 - Generate unit tests using Jest or Vitest
+- Choose between multiple AI models (GPT-4 and Claude 3 Sonnet)
 - Clean, modern UI built with Shadcn UI and Tailwind CSS
-- Real-time test generation using OpenAI's GPT-4
+- Real-time test generation using AI
 - Type-safe implementation with TypeScript
 
 ## Getting Started
@@ -16,9 +17,10 @@ A modern web application that uses AI to generate unit tests for your code. Buil
    ```bash
    npm install
    ```
-3. Create a `.env.local` file in the root directory and add your OpenAI API key:
+3. Create a `.env.local` file in the root directory and add your API keys:
    ```
-   OPENAI_API_KEY=your_api_key_here
+   OPENAI_API_KEY=your_openai_api_key_here
+   ANTHROPIC_API_KEY=your_anthropic_api_key_here
    ```
 4. Run the development server:
    ```bash
@@ -28,10 +30,11 @@ A modern web application that uses AI to generate unit tests for your code. Buil
 
 ## Usage
 
-1. Select your preferred test framework (Jest or Vitest)
-2. Paste your code into the input area
-3. Click "Generate Test" to create unit tests
-4. Copy the generated test code and use it in your project
+1. Select your preferred AI model (GPT-4 or Claude 3 Sonnet)
+2. Select your preferred test framework (Jest or Vitest)
+3. Paste your code into the input area
+4. Click "Generate Test" to create unit tests
+5. Copy the generated test code and use it in your project
 
 ## Technologies Used
 
@@ -40,6 +43,7 @@ A modern web application that uses AI to generate unit tests for your code. Buil
 - Tailwind CSS
 - Shadcn UI
 - OpenAI API
+- Anthropic API
 - Tanstack Query
 - Radix UI
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "temp-project",
       "version": "0.1.0",
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.40.1",
         "@radix-ui/react-label": "^2.1.4",
         "@radix-ui/react-slot": "^1.2.0",
         "@tanstack/react-query": "^5.75.2",
@@ -44,6 +45,36 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.40.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.40.1.tgz",
+      "integrity": "sha512-DJMWm8lTEM9Lk/MSFL+V+ugF7jKOn0M2Ujvb5fN8r2nY14aHbGPZ1k6sgjL+tpJ3VuOGJNG+4R83jEpOuYPv8w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "^18.11.18",
+        "@types/node-fetch": "^2.6.4",
+        "abort-controller": "^3.0.0",
+        "agentkeepalive": "^4.2.1",
+        "form-data-encoder": "1.7.2",
+        "formdata-node": "^4.3.2",
+        "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/@types/node": {
+      "version": "18.19.96",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.96.tgz",
+      "integrity": "sha512-PzBvgsZ7YdFs/Kng1BSW8IGv68/SPcOxYYhT7luxD7QyzIhFS1xPTpfK3K9eHBa7hVwlW+z8nN0mOd515yaduQ==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk/node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "license": "MIT"
     },
     "node_modules/@emnapi/core": {
       "version": "1.4.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "lint": "next lint"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.40.1",
     "@radix-ui/react-label": "^2.1.4",
     "@radix-ui/react-slot": "^1.2.0",
     "@tanstack/react-query": "^5.75.2",

--- a/src/app/api/generate-test/route.ts
+++ b/src/app/api/generate-test/route.ts
@@ -1,46 +1,26 @@
 import { NextResponse } from "next/server";
-import OpenAI from "openai";
-
-const openai = new OpenAI({
-  apiKey: process.env.OPENAI_API_KEY,
-});
+import { AIServiceFactory } from "@/services/ai-service-factory";
+import { AIModel } from "@/types/ai";
+import { AI_CONFIG } from "@/config/ai";
 
 export async function POST(request: Request) {
   try {
-    const { code, testFramework } = await request.json();
+    const {
+      code,
+      testFramework,
+      model = AI_CONFIG.defaultModel,
+    } = await request.json();
 
     if (!code) {
       return NextResponse.json({ error: "Code is required" }, { status: 400 });
     }
 
-    const prompt = `Generate a unit test for the following code using ${testFramework}. The test should be comprehensive and follow best practices. Include comments explaining the test cases.
-
-Code:
-${code}
-
-Generate the test code:`;
-
-    const completion = await openai.chat.completions.create({
-      model: "gpt-4",
-      messages: [
-        {
-          role: "system",
-          content:
-            "You are a helpful assistant that generates unit tests. You should provide complete, working test code that follows best practices.",
-        },
-        {
-          role: "user",
-          content: prompt,
-        },
-      ],
-      temperature: 0.7,
+    const aiService = AIServiceFactory.getService(model as AIModel);
+    const generatedTest = await aiService.generateTest({
+      code,
+      testFramework,
+      model: model as AIModel,
     });
-
-    const generatedTest = completion.choices[0]?.message?.content;
-
-    if (!generatedTest) {
-      throw new Error("No test generated");
-    }
 
     return new NextResponse(generatedTest, {
       headers: {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,17 +4,22 @@ import { useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import { useQuery } from "@tanstack/react-query";
+import { AIModel } from "@/types/ai";
+import { AI_CONFIG } from "@/config/ai";
 
 export default function Home() {
   const [code, setCode] = useState("");
-  const [testFramework, setTestFramework] = useState<"jest" | "vitest">("jest");
+  const [testFramework, setTestFramework] = useState(
+    AI_CONFIG.defaultTestFramework
+  );
+  const [model, setModel] = useState<AIModel>(AI_CONFIG.defaultModel);
 
   const {
     data: generatedTest,
     isLoading,
     refetch,
   } = useQuery({
-    queryKey: ["generateTest", code, testFramework],
+    queryKey: ["generateTest", code, testFramework, model],
     queryFn: async () => {
       if (!code) return null;
       const response = await fetch("/api/generate-test", {
@@ -22,7 +27,7 @@ export default function Home() {
         headers: {
           "Content-Type": "application/json",
         },
-        body: JSON.stringify({ code, testFramework }),
+        body: JSON.stringify({ code, testFramework, model }),
       });
       if (!response.ok) throw new Error("Failed to generate test");
       return response.text();
@@ -39,19 +44,48 @@ export default function Home() {
       <h1 className="text-3xl font-bold mb-6">AI Unit Test Generator</h1>
 
       <div className="space-y-4">
-        <div className="flex gap-4">
-          <Button
-            variant={testFramework === "jest" ? "default" : "outline"}
-            onClick={() => setTestFramework("jest")}
-          >
-            Jest
-          </Button>
-          <Button
-            variant={testFramework === "vitest" ? "default" : "outline"}
-            onClick={() => setTestFramework("vitest")}
-          >
-            Vitest
-          </Button>
+        <div className="space-y-4">
+          <div>
+            <label className="text-sm font-medium mb-2 block">
+              Select AI Model:
+            </label>
+            <div className="flex gap-4">
+              {Object.entries(AI_CONFIG.models).map(([modelId, modelInfo]) => (
+                <Button
+                  key={modelId}
+                  variant={model === modelId ? "default" : "outline"}
+                  onClick={() => setModel(modelId as AIModel)}
+                >
+                  {modelInfo.name}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <label className="text-sm font-medium mb-2 block">
+              Select Test Framework:
+            </label>
+            <div className="flex gap-4">
+              {Object.entries(AI_CONFIG.testFrameworks).map(
+                ([frameworkId, frameworkInfo]) => (
+                  <Button
+                    key={frameworkId}
+                    variant={
+                      testFramework === frameworkId ? "default" : "outline"
+                    }
+                    onClick={() =>
+                      setTestFramework(
+                        frameworkId as typeof AI_CONFIG.defaultTestFramework
+                      )
+                    }
+                  >
+                    {frameworkInfo.name}
+                  </Button>
+                )
+              )}
+            </div>
+          </div>
         </div>
 
         <div className="space-y-2">

--- a/src/config/ai.ts
+++ b/src/config/ai.ts
@@ -1,0 +1,28 @@
+import { AIModel } from "@/types/ai";
+
+export const AI_CONFIG = {
+  defaultModel: "gpt-4" as AIModel,
+  models: {
+    "gpt-4": {
+      id: "gpt-4" as const,
+      name: "GPT-4",
+      description: "OpenAI's most advanced model",
+    },
+    "claude-3-5-sonnet-latest": {
+      id: "claude-3-5-sonnet-latest" as const,
+      name: "Claude 3.5 Sonnet",
+      description: "Anthropic's latest Claude 3.5 Sonnet model",
+    },
+  },
+  defaultTestFramework: "jest" as const,
+  testFrameworks: {
+    jest: {
+      name: "Jest",
+      description: "JavaScript Testing Framework",
+    },
+    vitest: {
+      name: "Vitest",
+      description: "Vite-native testing framework",
+    },
+  },
+} as const;

--- a/src/services/ai-service-factory.ts
+++ b/src/services/ai-service-factory.ts
@@ -1,0 +1,25 @@
+import { AIModel, AIService } from "@/types/ai";
+import { OpenAIService } from "./openai-service";
+import { AnthropicService } from "./anthropic-service";
+import { AI_CONFIG } from "@/config/ai";
+
+export class AIServiceFactory {
+  private static services: Map<AIModel, AIService> = new Map();
+
+  static getService(model: AIModel): AIService {
+    if (!this.services.has(model)) {
+      switch (model) {
+        case AI_CONFIG.models["gpt-4"].id:
+          this.services.set(model, new OpenAIService());
+          break;
+        case AI_CONFIG.models["claude-3-5-sonnet-latest"].id:
+          this.services.set(model, new AnthropicService());
+          break;
+        default:
+          throw new Error(`Unsupported AI model: ${model}`);
+      }
+    }
+
+    return this.services.get(model)!;
+  }
+}

--- a/src/services/anthropic-service.ts
+++ b/src/services/anthropic-service.ts
@@ -1,0 +1,44 @@
+import Anthropic from "@anthropic-ai/sdk";
+import { AIGenerateTestParams, AIService } from "@/types/ai";
+
+export class AnthropicService implements AIService {
+  private client: Anthropic;
+
+  constructor() {
+    this.client = new Anthropic({
+      apiKey: process.env.ANTHROPIC_API_KEY,
+    });
+  }
+
+  async generateTest({
+    code,
+    testFramework,
+  }: AIGenerateTestParams): Promise<string> {
+    const prompt = `Generate a unit test for the following code using ${testFramework}. The test should be comprehensive and follow best practices. Include comments explaining the test cases.
+
+Code:
+${code}
+
+Generate the test code:`;
+
+    const message = await this.client.messages.create({
+      model: "claude-3-5-sonnet-latest",
+      max_tokens: 4000,
+      messages: [
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      temperature: 0.7,
+    });
+
+    // The first content block should be text
+    const contentBlock = message.content[0];
+    if (!contentBlock || contentBlock.type !== "text") {
+      throw new Error("No text content generated");
+    }
+
+    return contentBlock.text;
+  }
+}

--- a/src/services/openai-service.ts
+++ b/src/services/openai-service.ts
@@ -1,0 +1,48 @@
+import OpenAI from "openai";
+import { AIGenerateTestParams, AIService } from "@/types/ai";
+
+export class OpenAIService implements AIService {
+  private client: OpenAI;
+
+  constructor() {
+    this.client = new OpenAI({
+      apiKey: process.env.OPENAI_API_KEY,
+    });
+  }
+
+  async generateTest({
+    code,
+    testFramework,
+  }: AIGenerateTestParams): Promise<string> {
+    const prompt = `Generate a unit test for the following code using ${testFramework}. The test should be comprehensive and follow best practices. Include comments explaining the test cases.
+
+Code:
+${code}
+
+Generate the test code:`;
+
+    const completion = await this.client.chat.completions.create({
+      model: "gpt-4",
+      messages: [
+        {
+          role: "system",
+          content:
+            "You are a helpful assistant that generates unit tests. You should provide complete, working test code that follows best practices.",
+        },
+        {
+          role: "user",
+          content: prompt,
+        },
+      ],
+      temperature: 0.7,
+    });
+
+    const generatedTest = completion.choices[0]?.message?.content;
+
+    if (!generatedTest) {
+      throw new Error("No test generated");
+    }
+
+    return generatedTest;
+  }
+}

--- a/src/types/ai.ts
+++ b/src/types/ai.ts
@@ -1,0 +1,11 @@
+export type AIModel = "gpt-4" | "claude-3-5-sonnet-latest";
+
+export interface AIGenerateTestParams {
+  code: string;
+  testFramework: "jest" | "vitest";
+  model: AIModel;
+}
+
+export interface AIService {
+  generateTest(params: AIGenerateTestParams): Promise<string>;
+}


### PR DESCRIPTION
- Integrated Anthropic's Claude 3 Sonnet alongside OpenAI's GPT-4 for generating unit tests.
- Updated package.json and package-lock.json to include the @anthropic-ai/sdk dependency.
- Enhanced the UI to allow users to select between AI models and test frameworks.
- Refactored API service to dynamically choose the appropriate AI service based on user selection.
- Updated README to reflect new features and setup instructions for Anthropic API key.